### PR TITLE
Validation only content negotiation significant headers for value match

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 [![Build Status](https://travis-ci.org/apiaryio/gavel.js.png?branch=master)](https://travis-ci.org/apiaryio/gavel.js)
 [![Dependency Status](https://david-dm.org/apiaryio/gavel.js.png)](https://david-dm.org/apiaryio/gavel.js)
 [![devDependency Status](https://david-dm.org/apiaryio/gavel.js/dev-status.png)](https://david-dm.org/apiaryio/gavel.js#info=devDependencies)
-[![Coverage Status](https://coveralls.io/repos/apiaryio/gavel.js/badge.png?branch=coverage)](https://coveralls.io/r/apiaryio/gavel.js?branch=coverage)
+[![Coverage Status](https://coveralls.io/repos/apiaryio/gavel.js/badge.png)](https://coveralls.io/r/apiaryio/gavel.js)
+
 
 ![Gavel logo](https://raw.github.com/apiaryio/gavel/master/img/gavel.png)
+
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -12,16 +12,16 @@
   "dependencies": {
     "amanda": "^0.5.1",
     "async": "~0.9.0",
-    "clone": "~0.1.17",
-    "commander": "~2.3.0",
+    "clone": "^1.0.0",
+    "commander": "^2.6.0",
     "curl-trace-parser": "0.0.8",
     "googlediff": "0.1.0",
     "http-string-parser": "0.0.4",
-    "json-pointer": "~0.2.2",
+    "json-pointer": "^0.3.0",
     "jsonlint": "~1.6.0",
     "media-typer": "~0.3.0",
     "tv4": "~1.1.4",
-    "update": "~0.1.0"
+    "update": "^0.2.0"
   },
   "devDependencies": {
     "chai": "~1.9.0",

--- a/package.json
+++ b/package.json
@@ -24,18 +24,18 @@
     "update": "^0.2.0"
   },
   "devDependencies": {
-    "chai": "~1.9.0",
-    "coffee-script": "~1.8.0",
-    "mocha": "~1.21.4",
-    "cucumber": "~0.4.0",
-    "lodash": "~2.4.1",
-    "prettyjson": "~1.0.0",
+    "chai": "^2.1.0",
     "codo": "~2.0.6",
-    "sinon": "~1.10.2",
     "coffee-coverage": "~0.4.2",
-    "jscoverage": "~0.5.4",
+    "coffee-script": "~1.8.0",
     "coveralls": "~2.11.2",
-    "mocha-lcov-reporter": "0.0.1"
+    "cucumber": "~0.4.0",
+    "jscoverage": "~0.5.4",
+    "lodash": "^3.3.0",
+    "mocha": "^2.1.0",
+    "mocha-lcov-reporter": "0.0.1",
+    "prettyjson": "^1.1.0",
+    "sinon": "^1.12.2"
   },
   "scripts": {
     "test": "scripts/test",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chai": "^2.1.0",
     "codo": "~2.0.6",
     "coffee-coverage": "~0.4.2",
-    "coffee-script": "~1.8.0",
+    "coffee-script": "^1.9.1",
     "coveralls": "~2.11.2",
     "cucumber": "~0.4.0",
     "jscoverage": "~0.5.4",

--- a/src/mixins/validatable-http-message.coffee
+++ b/src/mixins/validatable-http-message.coffee
@@ -20,7 +20,7 @@ class Validatable
     @lowercaseHeaders()
 
     @validateHeaders() unless @headers == undefined || @expected.headers == undefined
-    @validateBody() unless @body == undefined || @expected.body == undefined
+    @validateBody() unless @body == undefined || (@expected.body == undefined && @expected.bodySchema == undefined)
     @validateStatusCode() unless @statusCode == undefined
     @validation
 

--- a/src/utils/schema-v4-generator.coffee
+++ b/src/utils/schema-v4-generator.coffee
@@ -106,7 +106,7 @@ class SchemaV4Generator
       if properties.valuesStrict.indexOf(objectId?.toLowerCase()) > -1
         schemaDict['enum'] = [baseObject]
 
-    if (properties.typesStrict and @isBaseType schemaType) or not @isBaseType schemaType
+    if (properties.typesStrict and @isBaseType schemaType) or (not @isBaseType schemaType) or firstLevel == true
       schemaDict["type"] = schemaType
 
     if schemaType is 'object' and Object.keys(baseObject).length > 0

--- a/src/utils/schema-v4-generator.coffee
+++ b/src/utils/schema-v4-generator.coffee
@@ -36,6 +36,13 @@ class SchemaV4Generator
     @schema = undefined
     @properties = properties || new SchemaV4Properties {}
 
+    # for handling strict values array as caseless
+    if Array.isArray @properties.valuesStrict
+      lowercased = []
+      for val in @properties.valuesStrict
+        lowercased.push val.toLowerCase()
+      @properties.valuesStrict = lowercased
+
   #generates json schema
   #@return [Object] generated json schema
   generate: () ->
@@ -92,8 +99,12 @@ class SchemaV4Generator
       else
         schemaDict['additionalItems'] = true
 
-    if properties.valuesStrict and @isBaseType schemaType
+    if properties.valuesStrict is true and @isBaseType schemaType
       schemaDict['enum'] = [baseObject]
+
+    else if Array.isArray(properties.valuesStrict) and @isBaseType schemaType
+      if properties.valuesStrict.indexOf(objectId?.toLowerCase()) > -1
+        schemaDict['enum'] = [baseObject]
 
     if (properties.typesStrict and @isBaseType schemaType) or not @isBaseType schemaType
       schemaDict["type"] = schemaType

--- a/src/validators/headers-json-example.coffee
+++ b/src/validators/headers-json-example.coffee
@@ -59,7 +59,16 @@ class HeadersJsonExample extends JsonSchema
   #@private
   getSchema: (data)->
     properties = new SchemaV4Properties {}
-    properties.set keysStrict: false, valuesStrict: true, typesStrict : false
+    properties.set
+      keysStrict: false
+      typesStrict : false
+      valuesStrict: [
+        'content-type'
+        'accept'
+        'accept-charset'
+        'accept-encoding'
+        'accept-language'
+      ]
 
     schemaGenerator = new SchemaV4Generator json: data, properties: properties
 

--- a/src/validators/json-example.coffee
+++ b/src/validators/json-example.coffee
@@ -28,13 +28,7 @@ class JsonExample extends JsonSchema
       outError['data'] = @expected
       throw outError
 
-    @expected = JSON.parse(@expected)
     @schema = @getSchema @expected
-
-    try
-      @real = JSON.parse(real)
-    catch error
-      validatorType = 'string'
 
     super @real, @schema
 

--- a/src/validators/json-schema.coffee
+++ b/src/validators/json-schema.coffee
@@ -51,7 +51,7 @@ class JsonSchema
 
     if typeof @schema == 'string'
       try
-        @schema = JSON.parse(schema)
+        @schema = JSON.parse(@schema)
       catch error
         outError = new errors.SchemaNotJsonParsableError 'JSON validator: schema: ' + error.message
         outError['schema'] = @schema

--- a/test/cucumber/step_definitions/validation_errors_thens.coffee
+++ b/test/cucumber/step_definitions/validation_errors_thens.coffee
@@ -1,6 +1,6 @@
 validationErrorsThens = () ->
   Given = When = Then = @.defineStep
-  
+
   Then /^Gavel will set some error for "([^"]*)"$/, (component, callback) ->
 
     @validate (error, result) =>
@@ -11,19 +11,17 @@ validationErrorsThens = () ->
       componentValidation = result[component]
       results = componentValidation['results']
       errorsCount = results.length
-      
+
       if not errorsCount > 0
-        callback.fail "Expected validation errors on '" + component + "', but there are no validation errors."  
-    
+        callback.fail "Expected validation errors on '" + component + "', but there are no validation errors."
+
       callback()
 
   Then /^Gavel will NOT set any errors for "([^"]*)"$/, (component, callback) ->
-    
+
     @validate (error, result) =>
       if error
         callback.fail "Error during validation: " + error
-
-
       component = @toCamelCase(component)
       componentValidation = result[component]
       results = componentValidation['results']
@@ -39,7 +37,7 @@ validationErrorsThens = () ->
 
 
       callback()
-      
+
   Then /^Request or Response is NOT valid$/, (callback) ->
     @isValid (error, result) =>
       if result
@@ -52,5 +50,5 @@ validationErrorsThens = () ->
         callback.fail "Request or Response is NOT valid and should be valid."
       callback()
 
- 
+
 module.exports = validationErrorsThens

--- a/test/cucumber/step_definitions/validators_steps.coffee
+++ b/test/cucumber/step_definitions/validators_steps.coffee
@@ -13,7 +13,7 @@ validatorStepDefs = () ->
   When /^you perform a failing validation on any validatable HTTP component$/, (callback) ->
     json1 = '{"a": "b"}'
     json2 = '{"c": "d"}'
-    
+
     @component = 'body'
 
     @real =
@@ -29,38 +29,40 @@ validatorStepDefs = () ->
     @validate (error, result) =>
       callback.fail "Got error during validation:\n" + error if error
       @results = JSON.parse JSON.stringify result
-      
+
       @isValid (error, result) ->
         callback.fail error if error
         @booleanResult = result
         callback()
 
-  Then /^the validator output for the HTTP component looks like the following JSON:$/, (expectedJson, callback) ->    
+  Then /^the validator output for the HTTP component looks like the following JSON:$/, (expectedJson, callback) ->
     expected = JSON.parse expectedJson
     real = @results[@component]
     if not _.isEqual real, expected
-      callback.fail "Not matched! Expected:" + "\n" + \
+      return callback.fail "Not matched! Expected:" + "\n" + \
                     JSON.stringify(expected, null, 2) + "\n" + \
                     "But got:" + "\n" + \
                     JSON.stringify(real, null, 2)
-    callback()
+
+    else
+      return callback()
 
   Then /^validated HTTP component is considered invalid$/, (callback) ->
     assert.isFalse @booleanResult
     callback()
-  
+
   Then /^the validator output for the HTTP component is valid against "([^"]*)" model JSON schema:$/, (model, schema, callback) ->
-    tv4.validate @results[@component], JSON.parse(schema), (error) ->
-      if error
-        if not Object.keys(error).length == 0
-          callback.fail "Expected no validation errors on schema but got:\n" +
-                    JSON.stringify(error, null, 2)
-      callback()
+    valid = tv4.validate @results[@component], JSON.parse(schema)
+    if not valid
+      return callback.fail "Expected no validation errors on schema but got:\n" +
+                JSON.stringify(tv4.error, null, 2)
+    else
+      return callback()
 
   Then /^each result entry under "([^"]*)" key must contain "([^"]*)" key$/, (key1, key2, callback) ->
     error = @results[@component]
     if error == undefined
-      callback.fail 'Validation result for "' + \ 
+      callback.fail 'Validation result for "' + \
         @component + \
         '" is undefined. Validations: ' + \
         JSON.stringify @results, null, 2
@@ -71,9 +73,9 @@ validatorStepDefs = () ->
 
   Then /^the output JSON contains key "([^"]*)" with one of the following values:$/, (key, table, callback) ->
     error = @results[@component]
-    
+
     validators = [].concat.apply [], table.raw()
-    
+
     assert.include validators, error[key]
     callback()
 
@@ -86,9 +88,9 @@ validatorStepDefs = () ->
       @expected['bodySchema'] = data
     else if type == 'application/vnd.apiary.http-headers+json'
       @expected[@component] = JSON.parse data
-    else      
+    else
       @expected[@component] = data
-    
+
     @expectedType = type
     callback()
 
@@ -99,7 +101,7 @@ validatorStepDefs = () ->
       @real[@component] = data
 
     @realType = type
-    callback()  
+    callback()
 
   When /^you perform validation on the HTTP component$/, (callback) ->
     @validate (error, result) =>
@@ -109,7 +111,7 @@ validatorStepDefs = () ->
       @results = result
       @componentResults = @results[@component]
       callback()
-  
+
   Then /^validator "([^"]*)" is used for validation$/, (validator, callback) ->
     usedValidator = @componentResults['validator']
     if validator != usedValidator
@@ -117,13 +119,13 @@ validatorStepDefs = () ->
         " instead of '" + validator + "'. Got validation results: " + \
         JSON.stringify(@results, null, 2)
     callback()
-  
+
   Then /^validation key "([^"]*)" looks like the following "([^"]*)":$/, (key, type, expected, callback) ->
     real = @componentResults[key]
     if type == "JSON"
       expected = JSON.parse expected
     else if type == "text"
-      # FIXME investigate how does cucumber docstrings handle 
+      # FIXME investigate how does cucumber docstrings handle
       # newlines and remove trim and remove this hack
       expected = expected + "\n"
 
@@ -135,9 +137,9 @@ validatorStepDefs = () ->
                       @inspect(real) + "\n" + \
                       "End"
     else if type == "text"
-      assert.equal expected, real    
+      assert.equal expected, real
     callback()
-  
+
   Then /^each result entry must contain "([^"]*)" key$/, (key, callback) ->
     @componentResults['results'].forEach (error) ->
       assert.include Object.keys(error), key

--- a/test/cucumber/support/world.coffee
+++ b/test/cucumber/support/world.coffee
@@ -4,13 +4,13 @@ vm = require 'vm'
 util = require 'util'
 {assert} = require 'chai'
 
-# Function exported in this file is called before each 
+# Function exported in this file is called before each
 module.exports = () ->
-  
+
   myWorld = (callback) ->
-    
+
     @codeBuffer = ""
-    
+
     @commandBuffer = ""
 
     # expected will contains data for creation of objects:
@@ -18,15 +18,15 @@ module.exports = () ->
     @expected = {}
 
     # real will contains data for creation of objects:
-    # HttpResponse, HttpRequest or HttpMessage   
+    # HttpResponse, HttpRequest or HttpMessage
     @real = {}
-    
+
     # contains parsed http objects for model valdiation
     @model = {}
-    
+
     # results for validators features
     @results = {}
-    
+
     # boolan validation result for whole HTTP Message
     @booleanResult = false
 
@@ -35,7 +35,7 @@ module.exports = () ->
     @componentResutls = null
 
     @expectedType = null
-    
+
     @realType = null
 
     @expectBlockEval = (block, expectedReturn, callback) ->
@@ -44,23 +44,23 @@ module.exports = () ->
       # I'm terribly sorry, but curly braces not asigned to any
       # variable in evaled string are interpreted as code block
       # not an Object literal, so I'm wrapping expected code output
-      # with brackets. 
+      # with brackets.
       # see: http://stackoverflow.com/questions/8949274/javascript-calling-eval-on-an-object-literal-with-functions
 
       expectedOutput = safeEval("(" + expectedReturn + ")",callback)
 
       realOutputInspect = util.inspect(realOutput)
       expectedOutputInspect = util.inspect(expectedOutput)
-      
-      try 
+
+      try
         assert.deepEqual realOutput, expectedOutput
-      catch error 
+      catch error
         callback.fail "Output of code buffer does not equal. Expected output:\n" \
                       + expectedOutputInspect \
                       + "\nbut got: \n" \
-                      + realOutputInspect + "\n" \ 
-                      + "Evaled code block:" + "\n" \ 
-                      + "- - - \n" \ 
+                      + realOutputInspect + "\n" \
+                      + "Evaled code block:" + "\n" \
+                      + "- - - \n" \
                       + block + "\n" \
                       + "- - - "
 
@@ -68,17 +68,17 @@ module.exports = () ->
       callback()
 
     safeEval = (code,callback) ->
-      
-      # I'm terribly sorry, it's no longer possible to manipulate module require/load 
-      # path inside node's process. So I'm prefixing require path by hard 
+
+      # I'm terribly sorry, it's no longer possible to manipulate module require/load
+      # path inside node's process. So I'm prefixing require path by hard
       # substitution in code to pretend to 'hit' is packaged module.
-      # 
+      #
       # further reading on node.js load paths:
       # http://nodejs.org/docs/v0.8.23/api/all.html#all_all_together
 
       code = code.replace("require('","require('../../../src/")
 
-      try  
+      try
         return eval(code)
       catch error
         callback.fail "Eval failed. Code buffer: \n\n" \
@@ -93,12 +93,12 @@ module.exports = () ->
 
     @validate = (cb) ->
       gavel.validate @real, @expected, 'response',  (error,result) ->
-        cb error, result 
+        cb error, result
 
-    
+
     # stupid HTTP parser for strings
     HTTP_LINE_DELIMITER = "\n"
-    
+
     @parseHeaders = (headersString) ->
       lines = headersString.split(HTTP_LINE_DELIMITER)
       headers = {}
@@ -120,53 +120,53 @@ module.exports = () ->
       parsed.statusCode = firstLine[1]
       parsed.statusMessage = firstLine[2]
 
-    @parseHttp = (type, string) ->   
-      throw Error 'Type must be "request" or "response"' unless type == 'request' or type == 'response' 
-      
+    @parseHttp = (type, string) ->
+      throw Error 'Type must be "request" or "response"' unless type == 'request' or type == 'response'
+
       parsed = {}
-       
+
       lines = string.split HTTP_LINE_DELIMITER
 
       if type == 'request'
-        @parseRequestLine parsed, lines.shift() 
+        @parseRequestLine parsed, lines.shift()
       if type == 'response'
-        @parseResponseLine parsed, lines.shift() 
-      
+        @parseResponseLine parsed, lines.shift()
+
       bodyLines = []
       headersLines = []
-      bodyEntered = false      
+      bodyEntered = false
       for line in lines
 
         if line == ''
-          bodyEntered = true      
+          bodyEntered = true
         else
           if bodyEntered
             bodyLines.push line
           else
             headersLines.push line
-      
+
       parsed.headers = @parseHeaders headersLines.join(HTTP_LINE_DELIMITER)
       parsed.body = bodyLines.join HTTP_LINE_DELIMITER
 
       parsed
-      
-    @toCamelCase = (input) -> 
-      result = input.replace /\s([a-z])/g, (strings) -> 
+
+    @toCamelCase = (input) ->
+      result = input.replace /\s([a-z])/g, (strings) ->
         strings[1].toUpperCase()
       result
 
     @toPascalCase = (input) ->
-      result = input.replace /(\w)(\w*)/g, (g0,g1,g2) -> 
+      result = input.replace /(\w)(\w*)/g, (g0,g1,g2) ->
         return g1.toUpperCase() + g2.toLowerCase()
       result = result.replace " ", ''
-    
+
     # debug functions
     @inspect = (data) ->
       if typeof data == 'object'
         return JSON.stringify(data, null, 2)
       else
         return data
-     
+
 
     @throw = (data) ->
       throw new Error @inspect(data)

--- a/test/fixtures.coffee
+++ b/test/fixtures.coffee
@@ -888,8 +888,8 @@ sampleHeaders = {
 }
 
 sampleHeadersDiff = {
-  "Content-Type": "application/json",
-  "header2": "header2_value_changed"
+  "Content-Type": "application/fancy-madiatype",
+  "header2": "header2_value"
 }
 
 sampleHeadersMiss = {
@@ -902,18 +902,22 @@ sampleHeadersAdd = {
   "header_added": "header_added_value",
 }
 
-sampleHeadersWithDateAndExpires = {
+sampleHeadersNonContentNegotiation = {
   "Content-Type": "application/json",
   "header2": "header2_value",
   "Date": "Fri, 30 Oct 1998 13:19:41 GMT",
   "Expires": "Fri, 30 Oct 1998 14:19:41 GMT",
+  "ETag": "123456789",
+  "Location": "/here"
 }
 
-sampleHeadersWithDateAndExpiresChanged = {
+sampleHeadersWithNonContentNegotiationChanged = {
   "Content-Type": "application/json",
   "header2": "header2_value",
   "Date": "Thu, 25 Jul 2013 23:59:59 GMT",
   "Expires": "Thu, 25 Jul 2013 23:59:59 GMT",
+  "ETag": "asdfghjk",
+  "Location": "/there"
 }
 
 sampleHeadersSchema = '''
@@ -1305,8 +1309,8 @@ module.exports =
   sampleHttpResponseSchema         : sampleHttpResponseSchema
   sampleHeadersSchema              : sampleHeadersSchema
   sampleHttpMessageSchema          : sampleHttpMessageSchema
-  sampleHeadersWithDateAndExpires  : sampleHeadersWithDateAndExpires
-  sampleHeadersWithDateAndExpiresChanged : sampleHeadersWithDateAndExpiresChanged
+  sampleHeadersWithNonContentNegotiationChanged  : sampleHeadersWithNonContentNegotiationChanged
+  sampleHeadersNonContentNegotiation : sampleHeadersNonContentNegotiation
 
 
 

--- a/test/unit/utils/schema-v4-generator-test.coffee
+++ b/test/unit/utils/schema-v4-generator-test.coffee
@@ -59,6 +59,81 @@ describe 'SchemaV4Generator', ->
     it 'should be expected non strict schema', ->
       assert.deepEqual JSON.parse(sampleJsonSchemaNonStrict),  sg.generate()
 
+  describe 'when I provide string with JSONized string', () ->
+    it 'should not throw exception', ->
+      fn = () ->
+        sg = new SchemaV4Generator json: '"Number of profiles deleted: com.viacom.auth.infrastructure.DocumentsUpdated@1"'
+        sg.properties =
+          keysStrict: false
+          typesStrict: false
+          valuesStrict: false
+        sg.generate()
+      assert.doesNotThrow fn
+
+  describe 'when empty object on root level',() ->
+    it 'should type validation in the schema on root level', () ->
+      sg = new SchemaV4Generator json: "{}"
+      sg.properties =
+        keysStrict: false
+        typesStrict: false
+        valuesStrict: false
+      assert.propertyVal sg.generate(), 'type', 'object'
+
+
+  describe 'when empty array on root level', () ->
+    it 'should type validation in the schema on root level', () ->
+      sg = new SchemaV4Generator json: "[]"
+      sg.properties =
+        keysStrict: false
+        typesStrict: false
+        valuesStrict: false
+      assert.propertyVal sg.generate(), 'type', 'array'
+
+  describe 'when string on root level', () ->
+    it 'should type validation in the schema on root level', () ->
+      sg = new SchemaV4Generator json: '"booboo"'
+      sg.properties =
+        keysStrict: false
+        typesStrict: false
+        valuesStrict: false
+      assert.propertyVal sg.generate(), 'type', 'string'
+
+  describe 'when number on root level', () ->
+    it 'should type validation in the schema on root level', () ->
+      sg = new SchemaV4Generator json: '1.1'
+      sg.properties =
+        keysStrict: false
+        typesStrict: false
+        valuesStrict: false
+      assert.propertyVal sg.generate(), 'type', 'number'
+
+  describe 'when integer on root level', () ->
+    it 'should type validation in the schema on root level', () ->
+      sg = new SchemaV4Generator json: '1'
+      sg.properties =
+        keysStrict: false
+        typesStrict: false
+        valuesStrict: false
+      assert.propertyVal sg.generate(), 'type', 'integer'
+
+  describe 'when boolean on root level', () ->
+    it 'should type validation in the schema on root level', () ->
+      sg = new SchemaV4Generator json: 'true'
+      sg.properties =
+        keysStrict: false
+        typesStrict: false
+        valuesStrict: false
+      assert.propertyVal sg.generate(), 'type', 'boolean'
+
+  describe 'when null on root level', () ->
+    it 'should type validation in the schema on root level', () ->
+      sg = new SchemaV4Generator json: 'null'
+      sg.properties =
+        keysStrict: false
+        typesStrict: false
+        valuesStrict: false
+      assert.propertyVal sg.generate(), 'type', 'null'
+
   describe 'generate strict schema only for some caseless keys', ->
 
     before ->

--- a/test/unit/utils/schema-v4-generator-test.coffee
+++ b/test/unit/utils/schema-v4-generator-test.coffee
@@ -1,7 +1,8 @@
 {assert} = require('chai')
 amanda = require 'amanda'
-{sampleJson, sampleJsonSchema, sampleJsonSchemaNonStrict} = require '../../fixtures'
+tv4 = require 'tv4'
 
+{sampleJson, sampleJsonSchema, sampleJsonSchemaNonStrict} = require '../../fixtures'
 {SchemaV4Generator, SchemaV4Properties} = require('../../../src/utils/schema-v4-generator')
 
 describe 'SchemaV4Generator', ->
@@ -57,6 +58,39 @@ describe 'SchemaV4Generator', ->
 
     it 'should be expected non strict schema', ->
       assert.deepEqual JSON.parse(sampleJsonSchemaNonStrict),  sg.generate()
+
+  describe 'generate strict schema only for some caseless keys', ->
+
+    before ->
+      expected =
+        "content-type": "application/json"
+        "location": "/here"
+      sg = new SchemaV4Generator json: expected
+      sg.properties =
+        keysStrict: true
+        typesStrict: false
+        valuesStrict: ['content-type']
+      sg.generate()
+
+    describe 'when missing key and its value completely', () ->
+      it 'should fail the validation against generated schema', () ->
+        realMissingKey =
+          "content-type": "application/json"
+        assert.notOk tv4.validateResult(realMissingKey, sg.schema).valid
+
+    describe 'when different value of strict', () ->
+      it 'should fail the validation against generated schema', () ->
+        realDifferentValueOfStrict =
+          "content-type": "application/hal+json"
+          "location": "/here"
+        assert.notOk tv4.validateResult(realDifferentValueOfStrict, sg.schema).valid
+
+    describe 'when different value of non strict', () ->
+      it 'should pass the validation against generated schema', () ->
+        realDifferentValueOfNonStrict =
+          "content-type": "application/json"
+          "location": "/there"
+        assert.ok tv4.validateResult(realDifferentValueOfNonStrict, sg.schema).valid
 
 
 

--- a/test/unit/validators/headers-json-example-validator-test.coffee
+++ b/test/unit/validators/headers-json-example-validator-test.coffee
@@ -40,7 +40,7 @@ describe 'HeadersJsonExample', ->
           result = headersValidator.validate()
           assert.equal result.length, 1
 
-    describe 'when value in provided headers differs', ->
+    describe 'when value of content negotiation header in provided headers differs', ->
       before ->
         headersValidator = new HeadersJsonExample fixtures.sampleHeadersDiffers , fixtures.sampleHeaders
       describe 'and i run validate()', ->
@@ -64,9 +64,9 @@ describe 'HeadersJsonExample', ->
           result = headersValidator.validate()
           assert.equal result.length, 2
 
-    describe 'when Date or Expires values header differs', ->
+    describe 'when non content negotiation header heeader values differs', ->
       before ->
-        headersValidator = new HeadersJsonExample fixtures.sampleHeadersWithDateAndExpiresChanged,  fixtures.sampleHeadersWithDateAndExpires
+        headersValidator = new HeadersJsonExample fixtures.sampleHeadersWithNonContentNegotiationChanged,  fixtures.sampleHeadersNonContentNegotiation
       describe 'and i run validate()', ->
         it "shouldn't return any errors", ->
           result = headersValidator.validate()

--- a/test/unit/validators/json-example-test.coffee
+++ b/test/unit/validators/json-example-test.coffee
@@ -13,6 +13,25 @@ describe 'JsonExample', ->
           bodyValidator = new JsonExample ('malformed':'malformed '),"{'header1': 'value1'}"
         assert.throws fn
 
+    describe 'when I provide string as real with JSONized string', () ->
+      it 'should not throw exception', ->
+        fn = () ->
+          bodyValidator = new JsonExample '"Number of profiles deleted: com.viacom.auth.infrastructure.DocumentsUpdated@1"', '{"header1": "value1"}'
+        assert.doesNotThrow fn
+
+    describe 'when I provide string as expected with JSONized string', () ->
+      it 'should not throw exception', ->
+        fn = () ->
+          bodyValidator = new JsonExample '{"header1": "value1"}', '"Number of profiles deleted: com.viacom.auth.infrastructure.DocumentsUpdated@1"'
+        fn()
+
+    describe 'when I provide string as expected and real with JSONized string', () ->
+      it 'should not throw exception', ->
+        fn = () ->
+          bodyValidator = new JsonExample '"Number of profiles deleted: com.viacom.auth.infrastructure.DocumentsUpdated@1"'
+          , '"Number of profiles deleted: com.viacom.auth.infrastructure.DocumentsUpdated@1"'
+        fn()
+
     describe 'when I provide non string expected data', ->
       it 'should throw exception', ->
         fn = () ->


### PR DESCRIPTION
- Headers validated for match of value given in expected are:
```
[
  'content-type'
  'accept'
  'accept-charset'
  'accept-encoding'
  'accept-language'
]
```

- All other headers are validated only for their presence, so values is are validated.
- All dependencies updated to latest
- Better handling primitive types on root level in JSON example validation
  - Strings in JSONs on root level were causing exception
  - On the root level was validated only typo of array or object
  - All JSON primitive types are now always validated on JSON root level