### PR TITLE
User friendly error messages

### DIFF
--- a/src/mixins/validatable-http-message.coffee
+++ b/src/mixins/validatable-http-message.coffee
@@ -142,7 +142,8 @@ class Validatable
         @validation.body.realType = contentType
       catch error
         message = {
-          message: 'Unknown real body media type. Content-type header is "' + contentType + '" but body is not a parseble JSON.'
+          message: 'Real body "Content-Type" header is "' +
+            contentType + '" but body is not a parseble JSON.'
           severity: 'error'
         }
         message.message  = message.message + "\n" + error.message
@@ -165,7 +166,7 @@ class Validatable
           parsed = JSON.parse @expected.bodySchema
           if typeof parsed != 'object' or Array.isArray parsed
             message = {
-              message: 'Expected body: JSON Schema provided, but it is not an Object'
+              message: 'Cant\'t validate. Expected body JSON Schema is not an Object'
               severity: 'error'
             }
             @validation.body.results.push message
@@ -173,7 +174,7 @@ class Validatable
             @validation.body.expectedType = 'application/schema+json'
         catch error
           message = {
-            message: 'Expected body: JSON Schema provided, but it is not a parseable JSON'
+            message: 'Can\'t validate. Expected body JSON Schema is not a parseable JSON'
             severity: 'error'
           }
           @validation.body.results.push message
@@ -190,7 +191,7 @@ class Validatable
           @validation.body.expectedType = expectedContentType
         catch error
           message = {
-            message: 'Expected body: Content-Type is ' + expectedContentType + ' but body is not a parseable JSON'
+            message: 'Can\'t validate. Expected body Content-Type is ' + expectedContentType + ' but body is not a parseable JSON'
             severity: 'error'
           }
           message.message = message.message + ": " +error.message
@@ -208,17 +209,11 @@ class Validatable
 
     @validation.body.results ?= []
 
-    message =
-      message: "No validator found for real data media type '#{@validation.body.realType}' and expected data media type '#{@validation.body.expectedType}'."
-      severity: 'error'
+    errorsLength = @validation.body.results.reduce (prev, result, index, array) ->
+      prev += 1 if result['severity'] == 'error'
+    , 0
 
-    if @validation.body.realType == null and @validation.body.expectedType == null
-      message = {
-        message: 'Unknown real and expected type. No validator found.'
-        severity: 'error'
-      }
-      @validation.body.results.push message
-    else
+    if errorsLength == 0
       if @isJsonContentType @validation.body.realType
         if @validation.body.expectedType == 'application/schema+json'
           @validation.body.validator = 'JsonSchema'
@@ -226,7 +221,7 @@ class Validatable
           @validation.body.validator = 'JsonExample'
         else
           message =
-            message: "Watchout for malformed JSON. Expected data media type ('#{@validation.body.expectedType}') does not match real media type ('#{@validation.body.realType}')."
+            message: "Can't validate real media type '#{@validation.body.realType}' against expected media type '#{@validation.body.realType}'."
             severity: 'error'
 
           @validation.body.results.push message
@@ -235,9 +230,17 @@ class Validatable
         if @validation.body.expectedType == 'text/plain'
           @validation.body.validator = 'TextDiff'
         else
+          message =
+            message: "Can't validate real media type '#{@validation.body.realType}' against expected media type '#{@validation.body.realType}'."
+            severity: 'error'
+
           @validation.body.results.push message
 
       else
+        message =
+          message: "Can't validate real media type '#{@validation.body.realType}' against expected media type '#{@validation.body.realType}'."
+          severity: 'error'
+
         @validation.body.results.push message
 
   runBodyValidator: () ->

--- a/src/mixins/validatable-http-message.coffee
+++ b/src/mixins/validatable-http-message.coffee
@@ -291,6 +291,12 @@ class Validatable
     results = validator.evaluateOutputToResults()
     @validation.statusCode.results = results.concat @validation.statusCode.results
 
+    @validation.statusCode.results = @validation.statusCode.results.map (current, index, arr) ->
+      if current.message = 'Real and expected data does not match.'
+        current.message = "Status code is not '#{expected}'"
+      current
+
+
   isJsonContentType: (contentType) ->
     result = false
 

--- a/src/utils/tv4-to-headers-message.coffee
+++ b/src/utils/tv4-to-headers-message.coffee
@@ -1,0 +1,21 @@
+module.exports = (message) ->
+  if message.indexOf("Missing required property:") > 1
+    headerName = message.split("Missing required property: ")[1]
+    newMessage = "Header '#{headerName}' is missing"
+
+  else if message.indexOf("No enum match for: ") > 1
+    splitted = message.split '\' No enum match for: "'
+
+    headerName = splitted[0]
+    headerName = headerName.replace(/^At '\//, '')
+
+    headerValue = splitted[1]
+    headerValue = headerValue.replace(/"$/, '')
+
+
+    newMessage = "Header '#{headerName}' doesn't have value '#{headerValue}'"
+
+  else
+    throw new Error 'Unknown tv4 error message can\'t convert to headers message.'
+
+  return newMessage

--- a/src/validators/headers-json-example.coffee
+++ b/src/validators/headers-json-example.coffee
@@ -1,8 +1,11 @@
 errors          = require '../errors'
 {JsonSchema}   = require './json-schema'
-{SchemaV4Generator, SchemaV4Properties} = require('../utils/schema-v4-generator')
+{SchemaV4Generator, SchemaV4Properties} = require '../utils/schema-v4-generator'
+tv4ToHeadersMessage = require '../utils/tv4-to-headers-message'
+
 jsonPointer = require 'json-pointer'
-type        = require 'is-type'
+type = require 'is-type'
+
 
 # Checks data, prepares validator and validates request or response headers against given expected headers or json schema
 # @author Peter Grilli <tully@apiary.io>
@@ -34,6 +37,14 @@ class HeadersJsonExample extends JsonSchema
 
     super @real, @schema
 
+  validate: ->
+
+    result = super()
+    if result.length > 0
+      for i in [0..(result.length - 1)]
+        result[i]['message'] = tv4ToHeadersMessage result[i]['message']
+
+    result
   #@private
   prepareHeaders: (headers) ->
     if not type.object(headers)

--- a/src/validators/json-schema.coffee
+++ b/src/validators/json-schema.coffee
@@ -123,7 +123,6 @@ class JsonSchema
 
     unless dataIsTheSame and schemaIsTheSame
       @output = @validatePrivate()
-
     return @output
 
   evaluateOutputToResults: (data) ->

--- a/test/unit/mixins/validatable-http-message-test.coffee
+++ b/test/unit/mixins/validatable-http-message-test.coffee
@@ -1133,10 +1133,13 @@ describe "Http validatable mixin", () ->
           instance.validate()
 
         it 'should set error message to results', () ->
-          assert.notEqual instance.validation.statusCode.results.length, 0
+          assert.equal instance.validation.statusCode.results.length, 1
 
         it 'should return false boolean result', () ->
           assert.isFalse instance.isValid()
+
+        it 'should set beutiful error message', () ->
+          assert.equal instance.validation.statusCode.results[0].message, "Status code is not '201'"
 
     describe '#isJsonContentType',  () ->
 

--- a/test/unit/mixins/validatable-http-message-test.coffee
+++ b/test/unit/mixins/validatable-http-message-test.coffee
@@ -748,7 +748,7 @@ describe "Http validatable mixin", () ->
                 results.forEach (result) ->
                   messages.push result.message
 
-                assert.include messages[0], 'Expected body: Content-Type is ' + contentType + ' but body is not a parseable JSON'
+                assert.include messages[0], 'is not a parseable JSON'
 
               it 'should add error message with lint result', () ->
                 expected = "Parse error on line 1:\n...\"creative?\": false, 'creativ': true }\n-----------------------^\nExpecting 'STRING', got 'undefined'"
@@ -788,6 +788,33 @@ describe "Http validatable mixin", () ->
                 'text/plain'
 
     describe "#setBodyValidator()", () ->
+      describe 'when there is an error prior its execution', () ->
+        before () ->
+          instance = new HttpResponse {
+            expected:
+              body: "{}"
+          }
+          instance.validation = {}
+          instance.validation.body  =
+            realType: null
+            expectedType: null
+          instance.validation.body.results = [
+            {
+              message: "I can't even"
+              severity: "error"
+            }
+          ]
+          instance.setBodyValidator()
+
+        it 'should not set any validator', () ->
+          assert.equal instance.validation.body.validator, null
+
+        it 'it should not add any error to results', () ->
+          results = instance.validation.body.results
+          console.log results
+          assert.equal results.length, 1
+
+
       describe 'real or expected type is null', () ->
         before () ->
           instance = new HttpResponse {

--- a/test/unit/utils/tv4-to-headers-message-test.coffee
+++ b/test/unit/utils/tv4-to-headers-message-test.coffee
@@ -1,0 +1,23 @@
+{assert} = require 'chai'
+tv4ToHeadersMessage = require '../../../src/utils/tv4-to-headers-message'
+
+describe 'tv4ToHeadersMessages()', ->
+
+  describe 'when message for missing header', ->
+    it 'should return message with right text', ->
+      tv4Message = 'At \'/header2\' Missing required property: header2'
+      message = tv4ToHeadersMessage(tv4Message)
+      assert.equal message, "Header 'header2' is missing"
+
+  describe 'when message for different value', ->
+    it 'should return message with right text', ->
+      tv4Message = 'At \'/content-type\' No enum match for: "application/fancy-madiatype"'
+      message = tv4ToHeadersMessage(tv4Message)
+      assert.equal message, "Header 'content-type' doesn't have value 'application/fancy-madiatype'"
+
+  describe 'when unknonw message', ->
+    it 'should throw an error', ->
+      fn = () ->
+        tv4ToHeadersMessage("String does not match pattern: {pattern}")
+      assert.throws fn
+

--- a/test/unit/validators/headers-json-example-validator-test.coffee
+++ b/test/unit/validators/headers-json-example-validator-test.coffee
@@ -1,5 +1,5 @@
 {assert} = require('chai')
-{HeadersJsonExample} = require('../../../src/validators/headers-json-example')
+{HeadersJsonExample} = require '../../../src/validators/headers-json-example'
 fixtures = require '../../fixtures'
 shared = require '../support/amanda-to-gavel-shared'
 
@@ -53,24 +53,35 @@ describe 'HeadersJsonExample', ->
           assert.lengthOf result, 0
 
     describe 'when key is missing in provided headers', ->
-      before ->
+      beforeEach ->
         headersValidator = new HeadersJsonExample fixtures.sampleHeadersMissing , fixtures.sampleHeaders
       describe 'and i run validate()', ->
         it "should return 1 error", ->
           result = headersValidator.validate()
           assert.equal result.length, 1
 
+        it 'should have beautiful error message', ->
+          result = headersValidator.validate()
+          assert.equal result[0].message, "Header 'header2' is missing"
+
     describe 'when value of content negotiation header in provided headers differs', ->
-      before ->
+      beforeEach ->
         headersValidator = new HeadersJsonExample fixtures.sampleHeadersDiffers , fixtures.sampleHeaders
+
       describe 'and i run validate()', ->
         it "should return 1 errors", ->
           result = headersValidator.validate()
           assert.equal result.length, 1
 
+        it 'should have beautiful error message', ->
+          result = headersValidator.validate()
+          console.log result
+          assert.equal result[0].message, "Header 'content-type' doesn't have value 'application/fancy-madiatype'"
+
     describe 'when key is added to provided headers', ->
       before ->
         headersValidator = new HeadersJsonExample fixtures.sampleHeadersAdded , fixtures.sampleHeaders
+
       describe 'and i run validate()', ->
         it "shouldn't return any errors", ->
           result = headersValidator.validate()
@@ -84,13 +95,15 @@ describe 'HeadersJsonExample', ->
           result = headersValidator.validate()
           assert.equal result.length, 2
 
-    describe 'when non content negotiation header heeader values differs', ->
+    describe 'when non content negotiation header header values differs', ->
       before ->
         headersValidator = new HeadersJsonExample fixtures.sampleHeadersWithNonContentNegotiationChanged,  fixtures.sampleHeadersNonContentNegotiation
+
       describe 'and i run validate()', ->
         it "shouldn't return any errors", ->
           result = headersValidator.validate()
           assert.equal result.length, 0
+
 
   describe '#validate()', () ->
     output = null


### PR DESCRIPTION
- get rid with confusing user facing messages with `null` media type
- get rid with redundant error messages from previous stages of validations
- custom messages for headers (get rid with JSON schema validator messages) 
- status code error message includes expected value

Note about implementation:

Tv4 validator can be supplied by custom validation messages, but the "At '/json/pointer'" part of the message is somewhere hardcoded and can't be customized. Due this limitation validation messages  from tv4 validator are parsed and sanitized to be human readable instead of some more sophisticated way how to do it.