### PR TITLE
Test also by browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "http-string-parser": "0.0.5",
     "is-type": "0.0.1",
     "json-pointer": "^0.5.0",
-    "jsonlint": "^1.6.2",
+    "jsonlint": "josdejong/jsonlint",
     "media-typer": "^0.3.0",
     "tv4": "^1.2.7"
   },
@@ -30,12 +30,15 @@
     "codo": "^2.1.0",
     "coffee-coverage": "^1.0.1",
     "coffee-script": "^1.10.0",
+    "coffeeify": "^2.0.1",
     "coveralls": "^2.11.9",
     "cucumber": "1.0.0",
+    "cz-conventional-changelog": "^1.1.6",
     "jscoverage": "^0.6.0",
     "lodash": "^4.13.1",
     "mocha": "^2.5.3",
     "mocha-lcov-reporter": "^1.2.0",
+    "mochify": "^2.18.1",
     "prettyjson": "^1.1.3",
     "sinon": "^1.17.4"
   },
@@ -78,5 +81,10 @@
   "readmeFilename": "README.md",
   "engines": {
     "node": "*"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }

--- a/scripts/mochify
+++ b/scripts/mochify
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd $(dirname $0)/..
+./node_modules/.bin/mochify ./test/**/*.coffee --transform=coffeeify --extension=.coffee

--- a/scripts/test
+++ b/scripts/test
@@ -4,6 +4,5 @@ git submodule update
 ./scripts/build
 cd $(dirname $0)
 ./cucumber 2>&1 \
-&& ./mocha 2>&1
-
-
+&& ./mocha 2>&1 \
+&& ./mochify 2>&1


### PR DESCRIPTION
The jsonlint dependency taken from fork due to https://github.com/zaach/jsonlint/issues/56.
It's the same solution we are using internally in Apiary.

Supersedes https://github.com/apiaryio/gavel.js/pull/61. Inspired by https://github.com/apiaryio/gavel2html/pull/2.