### PR TITLE
Update to the latest spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ $ npm install gavel
 
 Gavel.js is a JavaScript implementation of the [Gavel behavior specification](https://www.relishapp.com/apiary/gavel/) ([repository](https://github.com/apiaryio/gavel-spec)):
 
-- [Gavel.js-specific documentation](https://www.relishapp.com/apiary/gavel/docs/node-js/)
+- [Gavel.js-specific documentation](https://www.relishapp.com/apiary/gavel/docs/javascript/)
 - [CLI documentation](https://www.relishapp.com/apiary/gavel/docs/command-line-interface/)

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cross-spawn": "^4.0.0",
     "cucumber": "^1.2.2",
     "cz-conventional-changelog": "^1.1.6",
-    "gavel-spec": "^1.1.0",
+    "gavel-spec": "^1.2.0",
     "jscoverage": "^0.6.0",
     "lodash": "^4.13.1",
     "mocha": "^3.0.2",

--- a/scripts/cucumber.coffee
+++ b/scripts/cucumber.coffee
@@ -7,7 +7,7 @@ IS_WINDOWS = process.platform.match(/^win/)
 
 # Removing '@cli' behavior from tests due to
 # https://github.com/apiaryio/gavel-spec/issues/24
-tags = ['@nodejs', '~@proposal', '~@draft', '~@nodejs-pending']
+tags = ['@javascript', '~@proposal', '~@draft', '~@javascript-pending']
 tags.push('~@cli') if process.platform.match(/^win/)
 
 


### PR DESCRIPTION
`@nodejs` tag renamed to `@javascript`