### PR TITLE
Replace jsonlint

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "json-pointer": "^0.5.0",
     "jsonlint": "josdejong/jsonlint",
     "media-typer": "^0.3.0",
+    "parse-json": "^2.2.0",
     "tv4": "^1.2.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "http-string-parser": "0.0.5",
     "is-type": "0.0.1",
     "json-pointer": "^0.5.0",
-    "jsonlint": "josdejong/jsonlint",
     "media-typer": "^0.3.0",
     "parse-json": "^2.2.0",
     "tv4": "^1.2.7"

--- a/src/mixins/validatable-http-message.coffee
+++ b/src/mixins/validatable-http-message.coffee
@@ -142,11 +142,12 @@ class Validatable
         @validation.body.realType = contentType
       catch error
         message = {
-          message: 'Real body "Content-Type" header is "' +
-            contentType + '" but body is not a parseble JSON.'
+          message: """\
+            Real body 'Content-Type' header is '#{contentType}' \
+            but body is not a parseable JSON:\n#{error.message}\
+          """
           severity: 'error'
         }
-        message.message  = message.message + "\n" + error.message
         @validation.body.results.push message
     else
       try
@@ -163,7 +164,7 @@ class Validatable
     if @expected.bodySchema?
       if typeof @expected.bodySchema == 'string'
         try
-          parsed = JSON.parse @expected.bodySchema
+          parsed = parseJson @expected.bodySchema
           if typeof parsed != 'object' or Array.isArray parsed
             message = {
               message: 'Cant\'t validate. Expected body JSON Schema is not an Object'
@@ -174,7 +175,10 @@ class Validatable
             @validation.body.expectedType = 'application/schema+json'
         catch error
           message = {
-            message: 'Can\'t validate. Expected body JSON Schema is not a parseable JSON'
+            message: """\
+              Can't validate. Expected body JSON Schema 'Content-Type' is
+              not a parseable JSON:\n#{error.message}\
+            """
             severity: 'error'
           }
           @validation.body.results.push message
@@ -191,11 +195,12 @@ class Validatable
           @validation.body.expectedType = expectedContentType
         catch error
           message = {
-            message: 'Can\'t validate. Expected body "Content-Type" is "' +
-              expectedContentType + '" but body is not a parseable JSON.'
+            message: """\
+              Can't validate. Expected body 'Content-Type' is '#{expectedContentType}' \
+              but body is not a parseable JSON:\n#{error.message}\
+            """
             severity: 'error'
           }
-          message.message = message.message + "\n" + error.message
           @validation.body.results.push message
       else
         try

--- a/src/mixins/validatable-http-message.coffee
+++ b/src/mixins/validatable-http-message.coffee
@@ -191,10 +191,11 @@ class Validatable
           @validation.body.expectedType = expectedContentType
         catch error
           message = {
-            message: 'Can\'t validate. Expected body Content-Type is ' + expectedContentType + ' but body is not a parseable JSON'
+            message: 'Can\'t validate. Expected body "Content-Type" is "' +
+              expectedContentType + '" but body is not a parseable JSON.'
             severity: 'error'
           }
-          message.message = message.message + ": " +error.message
+          message.message = message.message + "\n" + error.message
           @validation.body.results.push message
       else
         try

--- a/src/mixins/validatable-http-message.coffee
+++ b/src/mixins/validatable-http-message.coffee
@@ -1,4 +1,4 @@
-jsonlint = require 'jsonlint'
+parseJson = require 'parse-json'
 mediaTyper = require 'media-typer'
 validators = require '../validators'
 
@@ -138,7 +138,7 @@ class Validatable
     contentType = @headers?['content-type']
     if @isJsonContentType contentType
       try
-        jsonlint.parse @body
+        parseJson @body
         @validation.body.realType = contentType
       catch error
         message = {
@@ -187,7 +187,7 @@ class Validatable
 
       if @isJsonContentType expectedContentType
         try
-          jsonlint.parse @expected.body
+          parseJson @expected.body
           @validation.body.expectedType = expectedContentType
         catch error
           message = {

--- a/test/unit/mixins/validatable-http-message-test.coffee
+++ b/test/unit/mixins/validatable-http-message-test.coffee
@@ -549,13 +549,16 @@ describe "Http validatable mixin", () ->
               assert.include results, 'error'
 
             it 'should add error message with lint result', () ->
-              expected = "Real body \"Content-Type\" header is \"" +
-                contentType + "\" but body is not a parsable JSON."
+              expected = """\
+                Real body 'Content-Type' header is '#{contentType}' but body is not a parseable JSON:
+                Unexpected token '\\'' at 1:22
+                {"creative?": false, 'creativ': true }
+                                     ^
+              """
               messages = []
               for result in instance.validation.body.results
                 messages.push result.message
-
-              assert.include messages[0], expected
+              assert.equal messages[0], expected
 
             it 'should not overwrite existing errors', () ->
               instance.validation.body.results = [
@@ -752,13 +755,17 @@ describe "Http validatable mixin", () ->
                 assert.include messages[0], 'is not a parseable JSON'
 
               it 'should add error message with lint result', () ->
-                expected = "Can't validate. Expected body \"Content-Type\" is \"" +
-                  contentType + "\" but body is not a parseable JSON."
+                expected = """\
+                  Can't validate. Expected body 'Content-Type' is '#{contentType}' but body is not a parseable JSON:
+                  Unexpected token '\\'' at 1:22
+                  {"creative?": false, 'creativ': true }
+                                       ^
+                """
                 messages = []
                 for result in instance.validation.body.results
                   messages.push result.message
 
-                assert.include messages[0], expected
+                assert.equal messages[0], expected
 
         describe 'expected headers have not content-type application/json', () ->
           describe 'expected body is a parseable JSON', () ->

--- a/test/unit/mixins/validatable-http-message-test.coffee
+++ b/test/unit/mixins/validatable-http-message-test.coffee
@@ -549,7 +549,8 @@ describe "Http validatable mixin", () ->
               assert.include results, 'error'
 
             it 'should add error message with lint result', () ->
-              expected = "Parse error on line 1:\n...\"creative?\": false, 'creativ': true }\n-----------------------^\nExpecting 'STRING', got 'undefined'"
+              expected = "Real body \"Content-Type\" header is \"" +
+                contentType + "\" but body is not a parsable JSON."
               messages = []
               for result in instance.validation.body.results
                 messages.push result.message
@@ -751,7 +752,8 @@ describe "Http validatable mixin", () ->
                 assert.include messages[0], 'is not a parseable JSON'
 
               it 'should add error message with lint result', () ->
-                expected = "Parse error on line 1:\n...\"creative?\": false, 'creativ': true }\n-----------------------^\nExpecting 'STRING', got 'undefined'"
+                expected = "Can't validate. Expected body \"Content-Type\" is \"" +
+                  contentType + "\" but body is not a parseable JSON."
                 messages = []
                 for result in instance.validation.body.results
                   messages.push result.message


### PR DESCRIPTION
The aim is to fix https://github.com/apiaryio/gavel.js/issues/83, i.e. to remove unmaintained `jsonlint` dependency while keeping the same functionality with detailed error messages if JSON parsing fails.

This PR is https://github.com/apiaryio/gavel.js/pull/84 successor. I took @lukateake commits, reworded them so they have Conventional Changelog prefixes and refactored a bit the error messages.
### Issues

When I made sure the detailed error message is tested in 9e2318d, I found out that while `parse-json` works correctly for node.js tests, it fails in browser tests:

```
expected

'Can\'t validate. Expected body \'Content-Type\' is \'application/hal+json\' but body is not a parseable JSON:\nundefined is not a constructor (evaluating \'Error.captureStackTrace(this, errorExError)\')'

to equal

'Can\'t validate. Expected body \'Content-Type\' is \'application/hal+json\' but body is not a parseable JSON:\nUnexpected token \'\\\'\' at 1:22\n{"creative?": false, \'creativ\': true }\n                     ^'
```

i.e. the parsing produces this error instead of the expected detailed error message:

```
undefined is not a constructor (evaluating \'Error.captureStackTrace(this, errorExError)
```

Unless this is resolved, I cannot get this merged. @lukateake @sindresorhus are you sure `parse-json` properly works in browser?
