### PR TITLE
Drop Node 4 support, test Node 8-10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: "node_js"
 node_js:
-  - "4"
   - "6"
+  - "8"
+  - "10"
 env:
   global:
     # GH_TOKEN and NPM_TOKEN encrypted by 'travis encrypt' utility


### PR DESCRIPTION
BREAKING CHANGE: From this release, Gavel.js is not tested on Node 4 anymore. Node 4 end of life is April 2018.