### PR TITLE
fix: do not load dependencies with `git+https`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "http-string-parser": "0.0.5",
     "is-type": "0.0.1",
     "json-pointer": "^0.6.0",
-    "jsonlint": "git+https://git@github.com/josdejong/jsonlint.git",
+    "jsonlint": "josdejong/jsonlint",
     "media-typer": "^0.3.0",
     "tv4": "^1.3.0"
   },


### PR DESCRIPTION
Using `git+https` unfortunately breaks on old machines running Git 2.1.x. It is unclear precisely which versions of Git it breaks, but I tested with two old versions:

* git version 2.1.2 : broken
* git version 2.3.3 : works

Since there should be no reason to use `git+https`, this will simply revert the line which was originally updated in commit 68c08ea.

This fixes issue https://github.com/apiaryio/gavel.js/issues/101


Test case
=======

I tried this branch out on the machine in question and the smallest possible test case I could come up with was to install Gavel directly with `npm install gavel` and see the failure. Then do the same for this PR branch.

```
$ git --version
git version 2.1.2
$ node --version
v8.10.0
$ npm --version
5.6.0

$ npm install apiaryio/gavel.js
npm ERR! Error while executing:
npm ERR! /usr/local/bin/git ls-remote -h -t https://git@github.com/josdejong/jsonlint.git
npm ERR! 
npm ERR! fatal: Unable to find remote helper for 'https'
npm ERR! 
npm ERR! exited with error code: 128

# and then the fixed:
$ npm install jesperronn/gavel.js#patch-1
npm WARN deprecated nomnom@1.8.1: Package no longer supported. Contact support@npmjs.com for more info.

+ gavel@0.0.0-semantically-released
added 29 packages in 10.502s
```
I deliberately hide some warnings related to npm not finding a package.json file