### PR TITLE
feat: replace jsonlint with json-parse-helpfulerror

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "googlediff": "0.1.0",
     "http-string-parser": "0.0.5",
     "is-type": "0.0.1",
+    "json-parse-helpfulerror": "1.0.3",
     "json-pointer": "0.6.0",
-    "jsonlint": "josdejong/jsonlint",
     "media-typer": "0.3.0",
     "tv4": "1.3.0"
   },

--- a/test/unit/mixins/validatable-http-message-test.coffee
+++ b/test/unit/mixins/validatable-http-message-test.coffee
@@ -549,12 +549,17 @@ describe "Http validatable mixin", () ->
               assert.include results, 'error'
 
             it 'should add error message with lint result', () ->
-              expected = "Parse error on line 1:\n...\"creative?\": false, 'creativ': true }\n-----------------------^\nExpecting 'STRING', got 'undefined'"
+              expected = """\
+                Real body 'Content-Type' header is '#{contentType}' but body is not a parseable JSON:
+                Unexpected token '\\'' at 1:22
+                {"creative?": false, 'creativ': true }
+                                     ^
+              """
               messages = []
               for result in instance.validation.body.results
                 messages.push result.message
 
-              assert.include messages[0], expected
+              assert.equal messages[0], expected
 
             it 'should not overwrite existing errors', () ->
               instance.validation.body.results = [
@@ -751,12 +756,17 @@ describe "Http validatable mixin", () ->
                 assert.include messages[0], 'is not a parseable JSON'
 
               it 'should add error message with lint result', () ->
-                expected = "Parse error on line 1:\n...\"creative?\": false, 'creativ': true }\n-----------------------^\nExpecting 'STRING', got 'undefined'"
+                expected = """\
+                  Can't validate. Expected body 'Content-Type' is '#{contentType}' but body is not a parseable JSON:
+                  Unexpected token '\\'' at 1:22
+                  {"creative?": false, 'creativ': true }
+                                       ^
+                """
                 messages = []
                 for result in instance.validation.body.results
                   messages.push result.message
 
-                assert.include messages[0], expected
+                assert.equal messages[0], expected
 
         describe 'expected headers have not content-type application/json', () ->
           describe 'expected body is a parseable JSON', () ->


### PR DESCRIPTION
`jsonlint` is unmaintained, and the fork referenced in `gavel` is not published.

my proposal is based on the pull request from @honzajavorek where `jsonlint` is replaced with `json-parse-helpfulerror` instead of `parse-json`. `json-parse-helpfulerror` appears to work in the browser as well as server.

https://github.com/apiaryio/gavel.js/pull/85