### PR TITLE
Maps status code validation error to contain real/expected status codes

### DIFF
--- a/lib/next/test/integration/validateMessage.test.js
+++ b/lib/next/test/integration/validateMessage.test.js
@@ -299,7 +299,7 @@ describe('validateMessage', () => {
           assert.propertyVal(
             result.statusCode.results[0],
             'message',
-            'Real and expected data does not match.'
+            `Status code is '400' instead of '200'`
           );
         });
       });

--- a/lib/next/test/unit/units/validateStatusCode.test.js
+++ b/lib/next/test/unit/units/validateStatusCode.test.js
@@ -64,7 +64,7 @@ describe('validateStatusCode', () => {
         assert.propertyVal(
           result.results[0],
           'message',
-          'Real and expected data does not match.'
+          `Status code is '200' instead of '400'`
         );
       });
     });

--- a/lib/next/units/validateStatusCode.js
+++ b/lib/next/units/validateStatusCode.js
@@ -10,13 +10,23 @@ const APIARY_STATUS_CODE_TYPE = 'text/vnd.apiary.status-code';
 function validateStatusCode(real, expected) {
   const validator = new TextDiff(real.statusCode, expected.statusCode);
   const rawData = validator.validate();
+  const results = validator.evaluateOutputToResults();
 
   return {
     validator: 'TextDiff',
     realType: APIARY_STATUS_CODE_TYPE,
     expectedType: APIARY_STATUS_CODE_TYPE,
     rawData,
-    results: validator.evaluateOutputToResults()
+    results: results.map((result) =>
+      Object.assign({}, result, {
+        message:
+          result.message === 'Real and expected data does not match.'
+            ? `Status code is '${real.statusCode}' instead of '${
+                expected.statusCode
+              }'`
+            : result.message
+      })
+    )
   };
 }
 


### PR DESCRIPTION
Adds explicit mapping of `statusCode` validation results to produce expected error messages that include real and expected status codes. Fixes failing tests in Dredd pipeline when using the newest release of Gavel.

## GitHub

- Closes #167 