### PR TITLE
feat: uses plain strings comparison for statusCode validation

### DIFF
--- a/lib/next/units/validateStatusCode.js
+++ b/lib/next/units/validateStatusCode.js
@@ -1,5 +1,3 @@
-const { TextDiff } = require('../../validators/text-diff');
-
 const APIARY_STATUS_CODE_TYPE = 'text/vnd.apiary.status-code';
 
 /**
@@ -8,25 +6,24 @@ const APIARY_STATUS_CODE_TYPE = 'text/vnd.apiary.status-code';
  * @param {number} expected
  */
 function validateStatusCode(real, expected) {
-  const validator = new TextDiff(real.statusCode, expected.statusCode);
-  const rawData = validator.validate();
-  const results = validator.evaluateOutputToResults();
+  const results = [];
+  const isValid = real.statusCode === expected.statusCode;
+
+  if (!isValid) {
+    results.push({
+      message: `Status code is '${real.statusCode}' instead of '${
+        expected.statusCode
+      }'`,
+      severity: 'error'
+    });
+  }
 
   return {
     validator: 'TextDiff',
     realType: APIARY_STATUS_CODE_TYPE,
     expectedType: APIARY_STATUS_CODE_TYPE,
-    rawData,
-    results: results.map((result) =>
-      Object.assign({}, result, {
-        message:
-          result.message === 'Real and expected data does not match.'
-            ? `Status code is '${real.statusCode}' instead of '${
-                expected.statusCode
-              }'`
-            : result.message
-      })
-    )
+    rawData: '',
+    results
   };
 }
 


### PR DESCRIPTION
Uses plain string comparison to validate `statusCode` of given HTTP messages. Uses strict comparison since statusCode is normalized to always be a string, and is coerced to an empty string when not set.

## GitHub

- Closes #159 

## Caveats

- One of the reasons we previously used `TextDiff` is because of the `rawData` is produces (result of `validator.validate()`). That `rawData` is asserted by Cucumber tests. We should watch out for that.