### PR TITLE
Checks HTTP message properties on the "expected" message

### DIFF
--- a/lib/next/test/integration/validateMessage.test.js
+++ b/lib/next/test/integration/validateMessage.test.js
@@ -1,6 +1,26 @@
 const { assert } = require('chai');
 const { validateMessage } = require('../../validateMessage');
 
+const validator = (obj, expected) => {
+  it(`has "${expected}" validator`, () => {
+    assert.propertyVal(obj, 'validator', expected);
+  });
+};
+
+const createTypeAssertion = (typeName, propName) => (obj, expected) => {
+  it(`has "${expected}" ${typeName} type`, () => {
+    assert.propertyVal(obj, propName, expected);
+  });
+};
+
+const realType = createTypeAssertion('real', 'realType');
+const expectedType = createTypeAssertion('expected', 'expectedType');
+const noErrors = (obj) => {
+  it('has no errors', () => {
+    assert.lengthOf(obj.results, 0);
+  });
+};
+
 describe('validateMessage', () => {
   describe('with matching requests', () => {
     const request = {
@@ -25,47 +45,17 @@ describe('validateMessage', () => {
     });
 
     describe('headers', () => {
-      it('has "HeadersJsonExample" validator', () => {
-        assert.propertyVal(result.headers, 'validator', 'HeadersJsonExample');
-      });
-
-      it('has "application/vnd.apiary.http-headers+json" real headers type', () => {
-        assert.propertyVal(
-          result.headers,
-          'realType',
-          'application/vnd.apiary.http-headers+json'
-        );
-      });
-
-      it('has "application/vnd.apiary.http-headers+json" expected headers type', () => {
-        assert.propertyVal(
-          result.headers,
-          'expectedType',
-          'application/vnd.apiary.http-headers+json'
-        );
-      });
-
-      it('has no errors', () => {
-        assert.lengthOf(result.headers.results, 0);
-      });
+      validator(result.headers, 'HeadersJsonExample');
+      expectedType(result.headers, 'application/vnd.apiary.http-headers+json');
+      realType(result.headers, 'application/vnd.apiary.http-headers+json');
+      noErrors(result.headers);
     });
 
     describe('body', () => {
-      it('has "JsonExample" validator', () => {
-        assert.propertyVal(result.body, 'validator', 'JsonExample');
-      });
-
-      it('has "application/json" real body type', () => {
-        assert.propertyVal(result.body, 'realType', 'application/json');
-      });
-
-      it('has "application/json" expected body type', () => {
-        assert.propertyVal(result.body, 'expectedType', 'application/json');
-      });
-
-      it('has no errors', () => {
-        assert.lengthOf(result.body.results, 0);
-      });
+      validator(result.body, 'JsonExample');
+      expectedType(result.body, 'application/json');
+      realType(result.body, 'application/json');
+      noErrors(result.body);
     });
   });
 
@@ -74,9 +64,9 @@ describe('validateMessage', () => {
       {
         method: 'POST',
         headers: {
-          'content-type': 'application/json'
+          'Content-Type': 'application/json'
         },
-        body: '{ "lookHere": "foo" }'
+        body: '{ "foo": "bar" }'
       },
       {
         method: 'PUT',
@@ -103,43 +93,16 @@ describe('validateMessage', () => {
     });
 
     describe('headers', () => {
-      it('has "HeadersJsonExample" validator', () => {
-        assert.propertyVal(result.headers, 'validator', 'HeadersJsonExample');
-      });
-
-      it('has "application/vnd.apiary.http-headers+json" as real type', () => {
-        assert.propertyVal(
-          result.headers,
-          'realType',
-          'application/vnd.apiary.http-headers+json'
-        );
-      });
-
-      it('has "application/vnd.apiary.http-headers+json" expected type', () => {
-        assert.propertyVal(
-          result.headers,
-          'expectedType',
-          'application/vnd.apiary.http-headers+json'
-        );
-      });
-
-      it('has no errors', () => {
-        assert.lengthOf(result.headers.results, 0);
-      });
+      validator(result.headers, 'HeadersJsonExample');
+      expectedType(result.headers, 'application/vnd.apiary.http-headers+json');
+      realType(result.headers, 'application/vnd.apiary.http-headers+json');
+      noErrors(result.headers);
     });
 
     describe('body', () => {
-      it('has "JsonExample" validator', () => {
-        assert.propertyVal(result.body, 'validator', 'JsonExample');
-      });
-
-      it('has "application/json" real type', () => {
-        assert.propertyVal(result.body, 'realType', 'application/json');
-      });
-
-      it('has "application/json" expected type', () => {
-        assert.propertyVal(result.body, 'expectedType', 'application/json');
-      });
+      validator(result.body, 'JsonExample');
+      expectedType(result.body, 'application/json');
+      realType(result.body, 'application/json');
 
       describe('produces an error', () => {
         it('exactly one error', () => {
@@ -184,73 +147,24 @@ describe('validateMessage', () => {
     });
 
     describe('statusCode', () => {
-      it('has "TextDiff" validator', () => {
-        assert.propertyVal(result.statusCode, 'validator', 'TextDiff');
-      });
-
-      it('has "text/vnd.apiary.status-code" real type', () => {
-        assert.propertyVal(
-          result.statusCode,
-          'realType',
-          'text/vnd.apiary.status-code'
-        );
-      });
-
-      it('has "text/vnd.apiary.status-code" expected type', () => {
-        assert.propertyVal(
-          result.statusCode,
-          'expectedType',
-          'text/vnd.apiary.status-code'
-        );
-      });
-
-      it('has no errors', () => {
-        assert.lengthOf(result.statusCode.results, 0);
-      });
+      validator(result.statusCode, 'TextDiff');
+      expectedType(result.statusCode, 'text/vnd.apiary.status-code');
+      realType(result.statusCode, 'text/vnd.apiary.status-code');
+      noErrors(result.statusCode);
     });
 
     describe('headers', () => {
-      it('has "HeadersJsonExample" validator', () => {
-        assert.propertyVal(result.headers, 'validator', 'HeadersJsonExample');
-      });
-
-      it('has "application/vnd.apiary.http-headers+json" real type', () => {
-        assert.propertyVal(
-          result.headers,
-          'realType',
-          'application/vnd.apiary.http-headers+json'
-        );
-      });
-
-      it('has "application/vnd.apiary.http-headers+json" expected type', () => {
-        assert.propertyVal(
-          result.headers,
-          'expectedType',
-          'application/vnd.apiary.http-headers+json'
-        );
-      });
-
-      it('has no errors', () => {
-        assert.lengthOf(result.headers.results, 0);
-      });
+      validator(result.headers, 'HeadersJsonExample');
+      expectedType(result.headers, 'application/vnd.apiary.http-headers+json');
+      realType(result.headers, 'application/vnd.apiary.http-headers+json');
+      noErrors(result.headers);
     });
 
     describe('body', () => {
-      it('has "JsonExample" validator', () => {
-        assert.propertyVal(result.body, 'validator', 'JsonExample');
-      });
-
-      it('has "application/json" real type', () => {
-        assert.propertyVal(result.body, 'realType', 'application/json');
-      });
-
-      it('has "application/json" expected type', () => {
-        assert.propertyVal(result.body, 'expectedType', 'application/json');
-      });
-
-      it('has no errors', () => {
-        assert.lengthOf(result.body.results, 0);
-      });
+      validator(result.body, 'JsonExample');
+      expectedType(result.body, 'application/json');
+      realType(result.body, 'application/json');
+      noErrors(result.body);
     });
   });
 
@@ -282,25 +196,9 @@ describe('validateMessage', () => {
     });
 
     describe('statusCode', () => {
-      it('has "TextDiff" validator', () => {
-        assert.propertyVal(result.statusCode, 'validator', 'TextDiff');
-      });
-
-      it('has "text/vnd.apiary.status-code" real type', () => {
-        assert.propertyVal(
-          result.statusCode,
-          'realType',
-          'text/vnd.apiary.status-code'
-        );
-      });
-
-      it('has "text/vnd.apiary.status-code" expected type', () => {
-        assert.propertyVal(
-          result.statusCode,
-          'expectedType',
-          'text/vnd.apiary.status-code'
-        );
-      });
+      validator(result.statusCode, 'TextDiff');
+      expectedType(result.statusCode, 'text/vnd.apiary.status-code');
+      realType(result.statusCode, 'text/vnd.apiary.status-code');
 
       describe('produces an error', () => {
         it('exactly one error', () => {
@@ -322,25 +220,9 @@ describe('validateMessage', () => {
     });
 
     describe('headers', () => {
-      it('has "HeadersJsonExample" validator', () => {
-        assert.propertyVal(result.headers, 'validator', 'HeadersJsonExample');
-      });
-
-      it('has "application/vnd.apiary.http-headers+json" real type', () => {
-        assert.propertyVal(
-          result.headers,
-          'realType',
-          'application/vnd.apiary.http-headers+json'
-        );
-      });
-
-      it('has "application/vnd.apiary.http-headers+json" real type', () => {
-        assert.propertyVal(
-          result.headers,
-          'realType',
-          'application/vnd.apiary.http-headers+json'
-        );
-      });
+      validator(result.headers, 'HeadersJsonExample');
+      expectedType(result.headers, 'application/vnd.apiary.http-headers+json');
+      realType(result.headers, 'application/vnd.apiary.http-headers+json');
 
       describe('produces an error', () => {
         it('exactly one error', () => {
@@ -388,51 +270,16 @@ describe('validateMessage', () => {
     });
 
     describe('statusCode', () => {
-      it('has "TextDiff" validator', () => {
-        assert.propertyVal(result.statusCode, 'validator', 'TextDiff');
-      });
-
-      it('has "text/vnd.apiary.status-code" real type', () => {
-        assert.propertyVal(
-          result.statusCode,
-          'realType',
-          'text/vnd.apiary.status-code'
-        );
-      });
-
-      it('has "text/vnd.apiary.status-code" expected type', () => {
-        assert.propertyVal(
-          result.statusCode,
-          'expectedType',
-          'text/vnd.apiary.status-code'
-        );
-      });
-
-      it('has no errors', () => {
-        assert.lengthOf(result.statusCode.results, 0);
-      });
+      validator(result.statusCode, 'TextDiff');
+      expectedType(result.statusCode, 'text/vnd.apiary.status-code');
+      realType(result.statusCode, 'text/vnd.apiary.status-code');
+      noErrors(result.statusCode);
     });
 
     describe('headers', () => {
-      it('has "HeadersJsonExample" validator', () => {
-        assert.propertyVal(result.headers, 'validator', 'HeadersJsonExample');
-      });
-
-      it('has "application/vnd.apiary.http-headers+json" real type', () => {
-        assert.propertyVal(
-          result.headers,
-          'realType',
-          'application/vnd.apiary.http-headers+json'
-        );
-      });
-
-      it('has "application/vnd.apiary.http-headers+json" expected type', () => {
-        assert.propertyVal(
-          result.headers,
-          'expectedType',
-          'application/vnd.apiary.http-headers+json'
-        );
-      });
+      validator(result.headers, 'HeadersJsonExample');
+      expectedType(result.headers, 'application/vnd.apiary.http-headers+json');
+      realType(result.headers, 'application/vnd.apiary.http-headers+json');
 
       describe('produces an error', () => {
         it('exactly one error', () => {
@@ -457,6 +304,108 @@ describe('validateMessage', () => {
             'message',
             `At '/content-type' Missing required property: content-type`
           );
+        });
+      });
+    });
+  });
+
+  describe('... validates all properties in expected message', () => {
+    const result = validateMessage(
+      {
+        body: 'doe'
+      },
+      {
+        statusCode: 200,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: '{ "foo": "bar" }'
+      }
+    );
+
+    it('contains all validatable keys', () => {
+      assert.hasAllKeys(result, ['isValid', 'statusCode', 'headers', 'body']);
+    });
+
+    describe('for properties present in both expected and real', () => {
+      describe('body', () => {
+        validator(result.body, null);
+        expectedType(result.body, 'application/json');
+        realType(result.body, 'text/plain');
+
+        describe('produces an error', () => {
+          it('exactly one error', () => {
+            assert.lengthOf(result.body.results, 1);
+          });
+
+          it('has "error" severity', () => {
+            assert.propertyVal(result.body.results[0], 'severity', 'error');
+          });
+
+          it('has explanatory message', () => {
+            assert.propertyVal(
+              result.body.results[0],
+              'message',
+              `Can't validate real media type 'text/plain' against expected media type 'application/json'.`
+            );
+          });
+        });
+      });
+    });
+
+    describe('for properties present in expected, but not in real', () => {
+      describe('statusCode', () => {
+        validator(result.statusCode, 'TextDiff');
+        expectedType(result.statusCode, 'text/vnd.apiary.status-code');
+        realType(result.statusCode, 'text/vnd.apiary.status-code');
+
+        describe('produces an error', () => {
+          it('exactly one error', () => {
+            assert.lengthOf(result.statusCode.results, 1);
+          });
+
+          it('has "error" severity', () => {
+            assert.propertyVal(
+              result.statusCode.results[0],
+              'severity',
+              'error'
+            );
+          });
+
+          it('has explanatory message', () => {
+            assert.propertyVal(
+              result.statusCode.results[0],
+              'message',
+              `Status code is 'undefined' instead of '200'`
+            );
+          });
+        });
+      });
+
+      describe('headers', () => {
+        validator(result.headers, 'HeadersJsonExample');
+        expectedType(
+          result.headers,
+          'application/vnd.apiary.http-headers+json'
+        );
+        realType(result.headers, 'application/vnd.apiary.http-headers+json');
+
+        describe('produces one error', () => {
+          it('exactly one error', () => {
+            assert.lengthOf(result.headers.results, 1);
+          });
+
+          it('has "error" severity', () => {
+            assert.propertyVal(result.headers.results[0], 'severity', 'error');
+          });
+
+          it('has explanatory message', () => {
+            assert.propertyVal(
+              result.headers.results[0],
+              'message',
+              `At '/content-type' Missing required property: content-type`
+            );
+          });
         });
       });
     });

--- a/lib/next/test/integration/validateMessage.test.js
+++ b/lib/next/test/integration/validateMessage.test.js
@@ -309,7 +309,7 @@ describe('validateMessage', () => {
     });
   });
 
-  describe('... validates all properties in expected message', () => {
+  describe('always validates expected properties', () => {
     const result = validateMessage(
       {
         body: 'doe'

--- a/lib/next/validateMessage.js
+++ b/lib/next/validateMessage.js
@@ -14,24 +14,21 @@ function validateMessage(realMessage, expectedMessage) {
   // for validation with the expected message.
   const real = normalize(coerce(realMessage));
 
-  // Weak coercion applies transformation only to the properties
-  // present in the given message. We don't want to mutate user's assertion.
-  // However, we do want to use the same coercion logic we do
-  // for strict coercion. Thus normalization and coercion are separate.
+  // Use weak coercion on expected message.
+  // This means that only the properties present in expected message
+  // will be coerced. We don't want to mutate user's assertion.
+  // However, we want to use the same coercion logic for any coercion type.
   const expected = normalize(coerceWeak(expectedMessage));
 
-  if (real.statusCode) {
+  if (expected.statusCode) {
     results.statusCode = validateStatusCode(real, expected);
   }
 
-  if (real.headers && expected.headers) {
+  if (expected.headers) {
     results.headers = validateHeaders(real, expected);
   }
 
-  if (
-    isset(real.body) &&
-    (isset(expected.body) || isset(expected.bodySchema))
-  ) {
+  if (isset(expected.body) || isset(expected.bodySchema)) {
     results.body = validateBody(real, expected);
   }
 


### PR DESCRIPTION
> BREAKING CHANGE: Validates all expected HTTP message properties

## Changes

- Checks expected HTTP messages properties to determine which properties to validate (previously: validated if a property is present in both expected and real messages)
- Adds tests that ensure _all_ expected HTTP message properties get validated, even if not present in the real message

## GitHub

- Closes #181 

## Roadmap

- [x] Adjust validation necessity logic
- [x] Add tests