### PR TITLE
fix: removes arrow functions to prevent context binding of Cucumber steps

### DIFF
--- a/test/cucumber/step_definitions/method_steps.js
+++ b/test/cucumber/step_definitions/method_steps.js
@@ -1,17 +1,17 @@
 module.exports = function() {
-  this.Given(
-    /^you expect HTTP message method "([^"]*)"$/,
-    (method, callback) => {
-      this.expected.method = method;
-      return callback();
-    }
-  );
+  this.Given(/^you expect HTTP message method "([^"]*)"$/, function(
+    method,
+    callback
+  ) {
+    this.expected.method = method;
+    return callback();
+  });
 
-  return this.When(
-    /^real HTTP message method is "([^"]*)"$/,
-    (method, callback) => {
-      this.real.message = method;
-      return callback();
-    }
-  );
+  return this.When(/^real HTTP message method is "([^"]*)"$/, function(
+    method,
+    callback
+  ) {
+    this.real.method = method;
+    return callback();
+  });
 };

--- a/test/cucumber/step_definitions/uri_steps.js
+++ b/test/cucumber/step_definitions/uri_steps.js
@@ -1,10 +1,16 @@
 module.exports = function() {
-  this.Given(/^you expect HTTP message URI "([^"]*)"$/, (uri, callback) => {
+  this.Given(/^you expect HTTP message URI "([^"]*)"$/, function(
+    uri,
+    callback
+  ) {
     this.expected.uri = uri;
     return callback();
   });
 
-  return this.When(/^real HTTP message URI is "([^"]*)"$/, (uri, callback) => {
+  return this.When(/^real HTTP message URI is "([^"]*)"$/, function(
+    uri,
+    callback
+  ) {
     this.real.uri = uri;
     return callback();
   });


### PR DESCRIPTION
Provides adjustments for Cucumber step definitions to properly execute `gavel-spec` features.

Coupled with https://github.com/apiaryio/gavel-spec/pull/52.