### PR TITLE
Adds json schema parsing check during body validation

### DIFF
--- a/lib/units/validateBody.js
+++ b/lib/units/validateBody.js
@@ -149,6 +149,27 @@ function getBodyValidator(realType, expectedType) {
 }
 
 /**
+ * Parses a given JSON Schema to ensure it's a valid JSON.
+ * @param {string} schema
+ */
+const validateJsonSchema = (schema) => {
+  try {
+    JSON.parse(schema);
+  } catch (error) {
+    throw new Error(`\
+Failed to parse a given JSON Schema:
+
+${schema}
+
+Please check if that is a valid JSON and a valid JSON Schema.
+
+Original parsing error:
+${error.stack}\
+    `);
+  }
+};
+
+/**
  * Validates given bodies of transaction elements.
  * @param {Object<string, any>} expected
  * @param {Object<string, any>} real
@@ -170,6 +191,13 @@ function validateBody(expected, real) {
     real.headers && real.headers['content-type'],
     'real'
   );
+
+  // Attempt to parse a given JSON Schema
+  // in case it's a raw string.
+  if (typeof expected.bodySchema === 'string') {
+    validateJsonSchema(expected.bodySchema);
+  }
+
   const [expectedTypeError, expectedType] = expected.bodySchema
     ? getBodySchemaType(expected.bodySchema)
     : getBodyType(

--- a/lib/units/validateBody.js
+++ b/lib/units/validateBody.js
@@ -102,10 +102,14 @@ function getBodySchemaType(bodySchema) {
   try {
     jph.parse(bodySchema);
     return [null, jsonSchemaType];
-  } catch (exception) {
-    const error = `Can't validate: expected body JSON Schema is not a parseable JSON:\n${exception.message}`;
+  } catch (error) {
+    // Gavel must throw when given malformed JSON Schema.
+    // See https://github.com/apiaryio/gavel.js/issues/203
+    throw new Error(`\
+Failed to validate HTTP message "body": given JSON Schema is not a valid JSON.
 
-    return [error, null];
+${error.message}\
+`);
   }
 }
 
@@ -149,27 +153,6 @@ function getBodyValidator(realType, expectedType) {
 }
 
 /**
- * Parses a given JSON Schema to ensure it's a valid JSON.
- * @param {string} schema
- */
-const validateJsonSchema = (schema) => {
-  try {
-    JSON.parse(schema);
-  } catch (error) {
-    throw new Error(`\
-Failed to parse a given JSON Schema:
-
-${schema}
-
-Please check that the given JSON Schema is a valid JSON.
-
-Original parsing error:
-${error.message}\
-    `);
-  }
-};
-
-/**
  * Validates given bodies of transaction elements.
  * @param {Object<string, any>} expected
  * @param {Object<string, any>} real
@@ -191,14 +174,6 @@ function validateBody(expected, real) {
     real.headers && real.headers['content-type'],
     'real'
   );
-
-  // Attempt to parse a given JSON Schema
-  // to verify that it's a valid JSON.
-  // TODO Move this into an input validation layer
-  // once such is introduced.
-  if (typeof expected.bodySchema === 'string') {
-    validateJsonSchema(expected.bodySchema);
-  }
 
   const [expectedTypeError, expectedType] = expected.bodySchema
     ? getBodySchemaType(expected.bodySchema)

--- a/lib/units/validateBody.js
+++ b/lib/units/validateBody.js
@@ -161,10 +161,10 @@ Failed to parse a given JSON Schema:
 
 ${schema}
 
-Please check if that is a valid JSON and a valid JSON Schema.
+Please check that the given JSON Schema is a valid JSON.
 
 Original parsing error:
-${error.stack}\
+${error.message}\
     `);
   }
 };
@@ -193,7 +193,9 @@ function validateBody(expected, real) {
   );
 
   // Attempt to parse a given JSON Schema
-  // in case it's a raw string.
+  // to verify that it's a valid JSON.
+  // TODO Move this into an input validation layer
+  // once such is introduced.
   if (typeof expected.bodySchema === 'string') {
     validateJsonSchema(expected.bodySchema);
   }

--- a/test/unit/units/validateBody.test.js
+++ b/test/unit/units/validateBody.test.js
@@ -469,7 +469,9 @@ describe('validateBody', () => {
       );
 
     it('must throw with malformed JSON schema error', () => {
-      expect(getResult).to.throw(/^Failed to parse a given JSON Schema:/g);
+      expect(getResult).to.throw(
+        /^Failed to validate HTTP message "body": given JSON Schema is not a valid JSON/g
+      );
     });
   });
 });

--- a/test/unit/units/validateBody.test.js
+++ b/test/unit/units/validateBody.test.js
@@ -444,4 +444,32 @@ describe('validateBody', () => {
       });
     });
   });
+
+  describe('given malformed JSON schema', () => {
+    const getResult = () =>
+      validateBody(
+        {
+          // Purposely invalid JSON Schema
+          bodySchema: `
+          {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "type": "object",
+            "properties": {
+                "href"": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+          `
+        },
+        {
+          body: '{ "foo": "bar" }'
+        }
+      );
+
+    it('must throw with malformed JSON schema error', () => {
+      expect(getResult).to.throw(/^Failed to parse a given JSON Schema:/g);
+    });
+  });
 });

--- a/test/unit/units/validateBody/getBodySchemaType.test.js
+++ b/test/unit/units/validateBody/getBodySchemaType.test.js
@@ -1,4 +1,4 @@
-const { assert } = require('chai');
+const { expect } = require('chai');
 const mediaTyper = require('media-typer');
 const { getBodySchemaType } = require('../../../../lib/units/validateBody');
 
@@ -17,14 +17,13 @@ describe('getBodySchemaType', () => {
         const [error, mediaType] = getBodySchemaType(value);
 
         it('returns "application/schema+json" media type', () => {
-          assert.deepEqual(
-            mediaType,
+          expect(mediaType).to.deep.equal(
             mediaTyper.parse('application/schema+json')
           );
         });
 
         it('has no errors', () => {
-          assert.isNull(error);
+          expect(error).to.be.null;
         });
       });
     });
@@ -41,31 +40,25 @@ describe('getBodySchemaType', () => {
         const [error, mediaType] = getBodySchemaType(jsonSchema);
 
         it('returns "application/schema+json" media type', () => {
-          assert.deepEqual(
-            mediaType,
+          expect(mediaType).to.deep.equal(
             mediaTyper.parse('application/schema+json')
           );
         });
 
         it('returns no errors', () => {
-          assert.isNull(error);
+          expect(error).to.be.null;
         });
       });
     });
   });
 
   describe('when given non-JSON string', () => {
-    const [error, mediaType] = getBodySchemaType('foo');
+    const run = () => getBodySchemaType('foo');
 
-    it('returns no media type', () => {
-      assert.isNull(mediaType);
-    });
-
-    it('returns parsing error', () => {
-      assert.match(
-        error,
-        /^Can't validate: expected body JSON Schema is not a parseable JSON:/
-      );
-    });
+    it('throws exception about invalid JSON', () => [
+      expect(run).to.throw(
+        /^Failed to validate HTTP message "body": given JSON Schema is not a valid JSON/
+      )
+    ]);
   });
 });


### PR DESCRIPTION
Performs given JSON Schema parsing during body validation to prevent processing of invalid or malformed JSON Schema. **Note that this performs no actual validation either a JSON Schema is a valid JSON Schema.**

## GitHub

- Fixes #203 
- Relates to the issue's origin: https://github.com/apiaryio/drafter/issues/719
- Discovered originally in https://github.com/apiaryio/apiary/commit/6b6c1723153bb0e0e358a1e0cb94fd9dc1b9b277