### PR TITLE
chore: uses node@12 in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: 'node_js'
 node_js:
   - '8'
   - '10'
+  - '12'
 cache:
   directories:
     - 'node_modules'


### PR DESCRIPTION
Uses NodeJS version 12 for CI.

- Relates to https://github.com/apiaryio/dredd/issues/1396