### PR TITLE
chore: removes "errors[i].values" from the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,7 @@ The code above would return the following validation `result`:
       },
       errors: [
         {
-          message: `Expected status code '200', but got '404'.`,
-          values: {
-            expected: '200',
-            actual: '404'
-          }
+          message: `Expected status code '200', but got '404'.`
         }
       ]
     },


### PR DESCRIPTION
I've noticed a discrepancy in the README, illustrating an error that includes the `values` key. That one has been removed after an internal discussion, and the `fields[fieldName].values` are recommended instead.