### PR TITLE
Adds deprecation warning on JSON Schema Draft 3 usage

### DIFF
--- a/lib/utils/deprecated.js
+++ b/lib/utils/deprecated.js
@@ -6,10 +6,9 @@
  * @param {string} message
  */
 module.exports = function deprecated(message) {
-  const isNode = typeof process !== 'undefined';
-  const shouldSuppressWarnings =
-    isNode && process.env.SUPPRESS_DEPRECATION_WARNINGS;
-  const shouldOutputMessage = isNode ? !shouldSuppressWarnings : true;
+  const shouldOutputMessage =
+    typeof process === 'undefined' ||
+    !process.env.SUPPRESS_DEPRECATION_WARNINGS;
 
   if (shouldOutputMessage) {
     console.warn(`DEPRECATED: ${message}`);

--- a/lib/utils/deprecated.js
+++ b/lib/utils/deprecated.js
@@ -1,0 +1,17 @@
+/* eslint-disable no-console */
+
+/**
+ * Outputs a deprecation message.
+ * Supports silencing the messages based on the environmental variable.
+ * @param {string} message
+ */
+module.exports = function deprecated(message) {
+  const isNode = typeof process !== 'undefined';
+  const shouldSuppressWarnings =
+    isNode && process.env.SUPPRESS_DEPRECATION_WARNINGS;
+  const shouldOutputMessage = isNode ? !shouldSuppressWarnings : true;
+
+  if (shouldOutputMessage) {
+    console.warn(`DEPRECATED: ${message}`);
+  }
+};

--- a/lib/utils/warn-on-deprecation.js
+++ b/lib/utils/warn-on-deprecation.js
@@ -5,7 +5,7 @@
  * Supports silencing the messages based on the environmental variable.
  * @param {string} message
  */
-module.exports = function deprecated(message) {
+module.exports = function warnOnDeprecation(message) {
   const shouldOutputMessage =
     typeof process === 'undefined' ||
     !process.env.SUPPRESS_DEPRECATION_WARNINGS;

--- a/lib/validators/json-schema-legacy.js
+++ b/lib/validators/json-schema-legacy.js
@@ -5,7 +5,7 @@ const jsonPointer = require('json-pointer');
 const { JsonSchemaValidator, META_SCHEMA } = require('./json-schema-next');
 const { ValidationErrors } = require('./validation-errors');
 const toGavelResult = require('../utils/to-gavel-result');
-const deprecated = require('../utils/deprecated');
+const warnOnDeprecation = require('../utils/warn-on-deprecation');
 
 /**
  * Returns a proper article for a given string.
@@ -77,7 +77,7 @@ class JsonSchemaLegacy extends JsonSchemaValidator {
 
     switch (this.jsonSchemaVersion) {
       case 'draftV3':
-        deprecated(
+        warnOnDeprecation(
           'JSON Schema Draft V3 is deprecated. Please use a newer version of JSON Schema (Draft V4-7).'
         );
 

--- a/lib/validators/json-schema-legacy.js
+++ b/lib/validators/json-schema-legacy.js
@@ -5,6 +5,7 @@ const jsonPointer = require('json-pointer');
 const { JsonSchemaValidator, META_SCHEMA } = require('./json-schema-next');
 const { ValidationErrors } = require('./validation-errors');
 const toGavelResult = require('../utils/to-gavel-result');
+const deprecated = require('../utils/deprecated');
 
 /**
  * Returns a proper article for a given string.
@@ -76,10 +77,10 @@ class JsonSchemaLegacy extends JsonSchemaValidator {
 
     switch (this.jsonSchemaVersion) {
       case 'draftV3':
-        // eslint-disable-line no-console
-        console.warn(
-          'DEPRECATED: JSON Schema Draft V3 is deprecated. Please use a newer version of JSON Schema (Draft V4-7).'
+        deprecated(
+          'JSON Schema Draft V3 is deprecated. Please use a newer version of JSON Schema (Draft V4-7).'
         );
+
         return this.validateUsingAmanda(parsedData);
       case 'draftV4':
         return this.validateUsingTV4(parsedData);

--- a/lib/validators/json-schema-legacy.js
+++ b/lib/validators/json-schema-legacy.js
@@ -76,6 +76,10 @@ class JsonSchemaLegacy extends JsonSchemaValidator {
 
     switch (this.jsonSchemaVersion) {
       case 'draftV3':
+        // eslint-disable-line no-console
+        console.warn(
+          'DEPRECATED: JSON Schema Draft V3 is deprecated. Please use a newer version of JSON Schema (Draft V4-7).'
+        );
         return this.validateUsingAmanda(parsedData);
       case 'draftV4':
         return this.validateUsingTV4(parsedData);


### PR DESCRIPTION
This pull request adds a deprecation warning whenever attempted to validate JSON Schema Draft V3 (Amanda). JSON Schema Draft 3 support is going to be dropped in the next major release of Gavel.

## GitHub

- Closes #361 