### PR TITLE
chore: remove node 8 from TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 # in https://travis-ci.org/apiaryio/gavel.js/settings
 language: 'node_js'
 node_js:
-  - '8'
   - '10'
   - '12'
 cache:


### PR DESCRIPTION
- Follow up to #533
- Removes Node v8 as a target for TravisCI configuration. Gavel now requires `node >=10`.