### PR TITLE
chore: add github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: ci
+on: push
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [10.x, 12.x, 14.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build
+      - run: npm test


### PR DESCRIPTION
As we've migrated from CircleCI, enables GitHub actions for continuous integration in the repo. 

Our current [Dredd GitHub actions](https://github.com/apiaryio/dredd/blob/5154957aace430be28e10c0df68255a92b393c2b/.github/workflows/run-test.yml) are used as inspiration. 