### PR TITLE
chore: add "semantic-release" to GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,14 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: npm test
+      
+  release:
+    runs-on: [ubuntu-latest]
+    needs: build
+    if: success() && github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Semantic release
+        run: npx semantic-release
+        env:
+          NPM_TOKEN: ${{ secrets.RELEASE_NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -16,11 +16,7 @@
     "lint": "eslint lib/**/*.js test/**/*.js",
     "test": "npm run test:unit && npm run test:features",
     "test:unit": "mocha \"test/**/*.test.js\"",
-    "test:features": "node scripts/cucumber.js",
-    "ci:lint": "npm run lint",
-    "ci:test": "npm test",
-    "ci:build": "npm run build",
-    "ci:release": "semantic-release"
+    "test:features": "node scripts/cucumber.js"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Configures the GitHub Actions pipeline to release Gavel using `semantic-release` automatically upon merges to the `master` branch. 

- [Using `semantic-release` CLI with GitHub Actions](https://github.com/semantic-release/cli#github-actions)

> I wasn't able to use [cycjimmy/semantic-release-action@v2](https://github.com/cycjimmy/semantic-release-action) because it was forbidden for our organization. 